### PR TITLE
agregado custom version comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import {View, Text} from 'react-native';
 import appCheckUpdates from '@janiscommerce/app-check-updates';
 
 const App = () => {
-  appCheckUpdates({curVersion:"0.0.1"});
+  appCheckUpdates({buildNumber:"2350"});
 	return (
 		<View>
 			<Text>app check updates</Text>
@@ -42,12 +42,10 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 ##### Notes:
 
-- You can uses [react-native-device-info](https://github.com/react-native-device-info/react-native-device-info) to get curVersion
-
 - In-app updates are available only to user accounts that own the app. So, make sure the account you’re using has downloaded your app from Google Play at least once before using the account to test in-app updates.
 
 ### Parameters
 
 | Options    | Type              | Description                            |
 | ---------- | ----------------- | -------------------------------------- |
-| curVersion | (required) String | The semver of your current app version |
+| buildNumber | (required) String | The build number of your current app version |

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -22,41 +22,41 @@ jest.mock('sp-react-native-in-app-updates', () => {
 
 describe('App check updates funtion', () => {
 	describe('Error handling', () => {
-		it('CurVersion is not a string', () => {
-			expect(appCheckUpdates({curVersion: ''})).resolves.toBe(null);
+		it('buildNumber is not a string', () => {
+			expect(appCheckUpdates({buildNumber: ''})).resolves.toBe(null);
 		});
 
 		it('A promise is reject', async () => {
 			mockIsDevEnv.mockReturnValueOnce(false);
 			mockCheckNeedUpdate.mockRejectedValueOnce(() => new Error());
-			const response = await appCheckUpdates({curVersion: '0.0.1'});
+			const response = await appCheckUpdates({buildNumber: '2050'});
 			expect(response).toEqual(false);
 		});
 
 		it('A promise is reject in debug mode', async () => {
 			mockIsDevEnv.mockReturnValueOnce(true);
 			mockCheckNeedUpdate.mockRejectedValueOnce(() => new Error());
-			const response = await appCheckUpdates({curVersion: '0.0.1'});
+			const response = await appCheckUpdates({buildNumber: '2050'});
 			expect(response).toEqual(false);
 		});
 	});
 
 	describe('Works correctly', () => {
 		it('CheckNeedsUpdate is called', async () => {
-			await appCheckUpdates({curVersion: '0.0.1'});
+			await appCheckUpdates({buildNumber: '2050'});
 
 			expect(mockCheckNeedUpdate).toHaveBeenCalled();
 		});
 
 		it('StartUpdate is called', async () => {
-			await appCheckUpdates({curVersion: '0.0.1'});
+			await appCheckUpdates({buildNumber: '2050'});
 
 			expect(mockStartUpdate).toHaveBeenCalled();
 		});
 
 		it('Is a android device', async () => {
 			Platform.OS = 'android';
-			await appCheckUpdates({curVersion: '0.0.1'});
+			await appCheckUpdates({buildNumber: '2050'});
 
 			expect(mockStartUpdate).toHaveBeenCalled();
 		});
@@ -67,7 +67,7 @@ describe('App check updates funtion', () => {
 				shouldUpdate: false,
 			}));
 
-			await appCheckUpdates({curVersion: '0.0.1'});
+			await appCheckUpdates({buildNumber: '2650'});
 
 			expect(mockStartUpdate).toHaveBeenCalledTimes(0);
 		});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,20 +3,20 @@ import SpInAppUpdates, {IAUUpdateKind, StartUpdateOptions} from 'sp-react-native
 import {isDevEnv, customVersionComparator} from './utils';
 
 interface IappCheckUpdates {
-	curVersion: string;
+	buildNumber: string;
 	isDebug?: boolean;
 }
 
-const appCheckUpdates = async ({curVersion, isDebug = false}: IappCheckUpdates) => {
+const appCheckUpdates = async ({buildNumber, isDebug = false}: IappCheckUpdates) => {
 	const isDevEnvironment = isDevEnv();
 	try {
-		if (typeof curVersion !== 'string' || !curVersion) {
+		if (typeof buildNumber !== 'string' || !buildNumber) {
 			return null;
 		}
 		const inAppUpdates = await new SpInAppUpdates(isDebug);
 
 		const storeResponse = await inAppUpdates.checkNeedsUpdate({
-			curVersion,
+			curVersion: buildNumber,
 			customVersionComparator,
 		});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import {Platform} from 'react-native';
 import SpInAppUpdates, {IAUUpdateKind, StartUpdateOptions} from 'sp-react-native-in-app-updates';
-import {isDevEnv} from './utils';
+import {isDevEnv, customVersionComparator} from './utils';
 
 interface IappCheckUpdates {
 	curVersion: string;
@@ -15,7 +15,10 @@ const appCheckUpdates = async ({curVersion, isDebug = false}: IappCheckUpdates) 
 		}
 		const inAppUpdates = await new SpInAppUpdates(isDebug);
 
-		const storeResponse = await inAppUpdates.checkNeedsUpdate({curVersion});
+		const storeResponse = await inAppUpdates.checkNeedsUpdate({
+			curVersion,
+			customVersionComparator,
+		});
 
 		if (storeResponse?.shouldUpdate) {
 			let updateOptions: StartUpdateOptions = {};

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,0 +1,17 @@
+import {customVersionComparator} from './index';
+
+describe('customVersionComparator funtion', () => {
+	describe('compare versions correctly', () => {
+		it('new version is equal to the current version', () => {
+			expect(customVersionComparator('1210', '1210')).toEqual(0);
+		});
+
+		it('new version is greater than the current version', async () => {
+			expect(customVersionComparator('1210', '1209')).toEqual(1);
+		});
+
+		it('new version is lower than current version', async () => {
+			expect(customVersionComparator('1210', '1211')).toEqual(-1);
+		});
+	});
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,13 @@ export const isDevEnv = () => {
 	return NODE_ENV !== 'production';
 };
 
+/**
+ * @name customVersionComparator
+ * @description compares 2 versions of the app to determine if an update is necessary
+ * @param {string} newAppV new version of the App
+ * @param {string} appVersion current version of the App
+ * @returns {number} returns 1 if the new version is greater, -1 if it is less, and 0 if they are equal
+ */
 export const customVersionComparator = (newAppV: string, appVersion: string): 0 | 1 | -1 => {
 	if (newAppV > appVersion) {
 		return 1;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,14 @@ export const isDevEnv = () => {
 	const {NODE_ENV} = env;
 	return NODE_ENV !== 'production';
 };
+
+export const customVersionComparator = (newAppV: string, appVersion: string): 0 | 1 | -1 => {
+	if (newAppV > appVersion) {
+		return 1;
+	}
+
+	if (newAppV < appVersion) {
+		return -1;
+	}
+	return 0;
+};


### PR DESCRIPTION
**Link de Tarea:**
https://janiscommerce.atlassian.net/browse/JUIP-81

**Link del ticket:**
https://janiscommerce.atlassian.net/browse/JPRN-1613

**Contexto:**
Dado que playstore nos retorna como codeversion el pipelineCode vamos a tener hacer las comparaciones de versiones con este numero.

**Necesidad:**
Crear una funcion custom que compare los codeVersions.

**Analisis funcional:**

Crear una funcion llamada customVersionComparator que se le pasara a la libreria para comparar las versiones.
Ahora lo que se pasara como curVersion sera buildNumber

En el scripts/set-environment.js pasar el buildNumber como nuevo parametro en envFileWithNewKeys (en local este dato no se puede obtener asi que colocar **"|| 0"** para evitar fallas)

Asi podemos obtener este dato desde 'env.json' y pasarlo como curVersion en la funcion. 

**Como se puede probar?:**

Instalandolo localmente con yalc sigiendo esta guia: [link](https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI)
Sustituyendo el package a linkear por @janiscommerce/app-check-updates

Instalar la peerDependenci

npm install sp-react-native-in-app-updates@1.2.0
luego en la home se importa la funcion y se ejecuta en algun useefect

import appCheckUpdates from '@janiscommerce/app-check-updates';

obener el buildNumber tal como se describio en el analisis funcional.

appCheckUpdates({curVersion:"2340"});
Las actualizaciones de la aplicación están disponibles solo para las cuentas de usuario que poseen la aplicación. Por lo tanto, asegúrese de que la cuenta que está utilizando haya descargado su aplicación de Google Play al menos una vez antes de usarla para probar las actualizaciones dentro de la aplicación.