### PR TITLE
Feature/appsrn 205 agregar addstatusupdatelisten

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,6 +5,7 @@ import mock from './mock.json';
 
 const mockStartUpdate = jest.fn();
 const mockCheckNeedUpdate = jest.fn().mockImplementation(() => mock);
+const mockAddStatusUpdateListener = jest.fn();
 const mockIsDevEnv = jest.spyOn(utils, 'isDevEnv');
 
 jest.mock('sp-react-native-in-app-updates', () => {
@@ -13,6 +14,7 @@ jest.mock('sp-react-native-in-app-updates', () => {
 		default: jest.fn(() => ({
 			checkNeedsUpdate: mockCheckNeedUpdate,
 			startUpdate: mockStartUpdate,
+			addStatusUpdateListener: mockAddStatusUpdateListener,
 		})),
 		IAUUpdateKind: {
 			FLEXIBLE: 1,
@@ -51,6 +53,7 @@ describe('App check updates funtion', () => {
 		it('StartUpdate is called', async () => {
 			await appCheckUpdates({buildNumber: '2050'});
 
+			expect(mockAddStatusUpdateListener).toHaveBeenCalled();
 			expect(mockStartUpdate).toHaveBeenCalled();
 		});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,16 @@
 import {Platform} from 'react-native';
-import SpInAppUpdates, {IAUUpdateKind, StartUpdateOptions} from 'sp-react-native-in-app-updates';
-import {isDevEnv, customVersionComparator} from './utils';
+import SpInAppUpdates, {
+	IAUUpdateKind,
+	StartUpdateOptions,
+	// IAUInstallStatus,
+	// StatusUpdateEvent,
+} from 'sp-react-native-in-app-updates';
+import {isDevEnv, customVersionComparator, onStatusUpdate} from './utils';
 
 interface IappCheckUpdates {
 	buildNumber: string;
 	isDebug?: boolean;
 }
-
 const appCheckUpdates = async ({buildNumber, isDebug = false}: IappCheckUpdates) => {
 	const isDevEnvironment = isDevEnv();
 	try {
@@ -20,6 +24,12 @@ const appCheckUpdates = async ({buildNumber, isDebug = false}: IappCheckUpdates)
 			customVersionComparator,
 		});
 
+		// const onStatusUpdate = async ({status}: StatusUpdateEvent) => {
+		// 	if (status === IAUInstallStatus.DOWNLOADED) {
+		// 		await inAppUpdates.installUpdate();
+		// 	}
+		// };
+
 		if (storeResponse?.shouldUpdate) {
 			let updateOptions: StartUpdateOptions = {};
 			if (Platform.OS === 'android') {
@@ -28,6 +38,7 @@ const appCheckUpdates = async ({buildNumber, isDebug = false}: IappCheckUpdates)
 					updateType: IAUUpdateKind.FLEXIBLE,
 				};
 			}
+			await inAppUpdates.addStatusUpdateListener((status) => onStatusUpdate(status, inAppUpdates));
 			await inAppUpdates.startUpdate(updateOptions);
 		}
 		return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,5 @@
 import {Platform} from 'react-native';
-import SpInAppUpdates, {
-	IAUUpdateKind,
-	StartUpdateOptions,
-	// IAUInstallStatus,
-	// StatusUpdateEvent,
-} from 'sp-react-native-in-app-updates';
+import SpInAppUpdates, {IAUUpdateKind, StartUpdateOptions} from 'sp-react-native-in-app-updates';
 import {isDevEnv, customVersionComparator, onStatusUpdate} from './utils';
 
 interface IappCheckUpdates {
@@ -24,12 +19,6 @@ const appCheckUpdates = async ({buildNumber, isDebug = false}: IappCheckUpdates)
 			customVersionComparator,
 		});
 
-		// const onStatusUpdate = async ({status}: StatusUpdateEvent) => {
-		// 	if (status === IAUInstallStatus.DOWNLOADED) {
-		// 		await inAppUpdates.installUpdate();
-		// 	}
-		// };
-
 		if (storeResponse?.shouldUpdate) {
 			let updateOptions: StartUpdateOptions = {};
 			if (Platform.OS === 'android') {
@@ -38,6 +27,7 @@ const appCheckUpdates = async ({buildNumber, isDebug = false}: IappCheckUpdates)
 					updateType: IAUUpdateKind.FLEXIBLE,
 				};
 			}
+			/* istanbul ignore next */
 			await inAppUpdates.addStatusUpdateListener((status) => onStatusUpdate(status, inAppUpdates));
 			await inAppUpdates.startUpdate(updateOptions);
 		}

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -30,7 +30,7 @@ describe('utils funtion', () => {
 		});
 	});
 	describe('onStatusUpdate funtion', () => {
-		it('new version is equal to the current version', async () => {
+		it('new version was downloaded and the installation begins', async () => {
 			const mockStatus = {
 				bytesDownloaded: 123,
 				totalBytesToDownload: 123,
@@ -41,11 +41,11 @@ describe('utils funtion', () => {
 			await expect(mockInstallUpdate).toHaveBeenCalled();
 		});
 
-		it('new version is equal to the current versions', async () => {
+		it('new version is being downloaded', async () => {
 			const mockStatus = {
 				bytesDownloaded: 123,
 				totalBytesToDownload: 123,
-				status: 4,
+				status: 2,
 			};
 			const inAppUpdates = await new SpInAppUpdates(false);
 			await onStatusUpdate(mockStatus, inAppUpdates);

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,7 +1,22 @@
-import {customVersionComparator} from './index';
+import SpInAppUpdates from 'sp-react-native-in-app-updates';
+import {customVersionComparator, onStatusUpdate} from './index';
 
-describe('customVersionComparator funtion', () => {
-	describe('compare versions correctly', () => {
+const mockInstallUpdate = jest.fn();
+
+jest.mock('sp-react-native-in-app-updates', () => {
+	return {
+		__esModule: true,
+		default: jest.fn(() => ({
+			installUpdate: mockInstallUpdate,
+		})),
+		IAUInstallStatus: {
+			DOWNLOADED: 11,
+		},
+	};
+});
+
+describe('utils funtion', () => {
+	describe('customVersionComparator funtion', () => {
 		it('new version is equal to the current version', () => {
 			expect(customVersionComparator('1210', '1210')).toEqual(0);
 		});
@@ -12,6 +27,29 @@ describe('customVersionComparator funtion', () => {
 
 		it('new version is lower than current version', async () => {
 			expect(customVersionComparator('1210', '1211')).toEqual(-1);
+		});
+	});
+	describe('onStatusUpdate funtion', () => {
+		it('new version is equal to the current version', async () => {
+			const mockStatus = {
+				bytesDownloaded: 123,
+				totalBytesToDownload: 123,
+				status: 11,
+			};
+			const inAppUpdates = await new SpInAppUpdates(false);
+			await onStatusUpdate(mockStatus, inAppUpdates);
+			await expect(mockInstallUpdate).toHaveBeenCalled();
+		});
+
+		it('new version is equal to the current versions', async () => {
+			const mockStatus = {
+				bytesDownloaded: 123,
+				totalBytesToDownload: 123,
+				status: 4,
+			};
+			const inAppUpdates = await new SpInAppUpdates(false);
+			await onStatusUpdate(mockStatus, inAppUpdates);
+			await expect(mockInstallUpdate).toHaveBeenCalledTimes(0);
 		});
 	});
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import SpInAppUpdates, {IAUInstallStatus, StatusUpdateEvent} from 'sp-react-native-in-app-updates';
 /* istanbul ignore next */
 /**
  * @name isDevEnv
@@ -25,4 +26,10 @@ export const customVersionComparator = (newAppV: string, appVersion: string): 0 
 		return -1;
 	}
 	return 0;
+};
+
+export const onStatusUpdate = async ({status}: StatusUpdateEvent, inAppUpdates: SpInAppUpdates) => {
+	if (status === IAUInstallStatus.DOWNLOADED) {
+		await inAppUpdates.installUpdate();
+	}
 };


### PR DESCRIPTION

**Link del ticket:**
https://janiscommerce.atlassian.net/browse/APPSRN-204

**Contexto:**
En la tarea JPRN-1565: Aviso de nueva actualizacion APP Picking
 
Se creo un package que tiene la función de avisar al usuario cuando tengamos nuevas actualizaciones disponibles, al implementar este nuevo package en la app de picking 

JPRN-1619: Implementar app-check-updates en Picking
 
nos dimos cuenta que se descarga la nueva versión de la app mas no se instala automáticamente. 

**Necesidad:**
Actualizar el package [npm: @janiscommerce/app-check-updates](https://www.npmjs.com/package/@janiscommerce/app-check-updates)  para que al descarga la nueva versión haga la actualización automáticamente.

**Analisis funcional:**

El package tiene un metodo llamado installUpdate que debemos ejecutar
se creo la funcion onStatusUpdate que inyectamos en inAppUpdates mediante el metodo addStatusUpdateListener
Que verifique el estado de la descarga y una vez completada ejecuta installUpdate.

**Como se puede probar?:**

Instalandolo localmente con yalc sigiendo esta guia: [link](https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI)
Sustituyendo el package a linkear por @janiscommerce/app-check-updates

Instalar la peerDependenci

npm install sp-react-native-in-app-updates@1.2.0
luego en la home se importa la funcion y se ejecuta en algun useefect

import appCheckUpdates from '@janiscommerce/app-check-updates';

obener el buildNumber tal como se describio en el analisis funcional.

appCheckUpdates({curVersion:"2340"});

Las actualizaciones de la aplicación están disponibles solo para las cuentas de usuario que poseen la aplicación. Por lo tanto, asegúrese de que la cuenta que está utilizando haya descargado su aplicación de Google Play al menos una vez antes de usarla para probar las actualizaciones dentro de la aplicación.

Lamentablemente en local no funciona bien, comienza la instalación mas se corta por algun error, para las pruebas se subió el codigo directamente a la app de picking en beta.
Para probar en beta hay que descargar la app en google play, subir una nueva version a beta, y una vez que este disponible en la playstore, abrir la app e ingresar a la home, ahi saltara el popup y se podra instalar.

**Evidencia**
![installUpdate](https://github.com/janis-commerce/app-check-updates/assets/69169114/9628224b-f673-409c-bd5c-216c96677569)

