### PR TITLE
se modifican la manera en que se exportan las funciones

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
 
     <application
       android:name=".MainApplication"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import appCheckUpdates from './index';
+import {appCheckUpdates} from './index';
 import * as utils from './utils';
 import {defaultResponse} from './utils';
 import * as updateFromStorefn from './modules/updateFromStore';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import updateFromStore from './modules/updateFromStore';
+import updateFromJanis from './modules/updateFromJanis';
 import {checkNeedsUpdateInJanis, defaultResponse} from './utils';
 
 interface IappCheckUpdates {
@@ -32,4 +33,4 @@ const appCheckUpdates = async ({buildNumber, isDebug = false, env, app}: IappChe
 	return defaultResponse;
 };
 
-export default appCheckUpdates;
+export {appCheckUpdates, updateFromJanis};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ interface IappCheckUpdates {
  * @param {boolean} isDebug is debug mode
  * @param {string} env environment of janis
  * @param {string} app App name
- * @returns {object} { hasCheckedUpdate: boolean, shouldUpdateFromJanis: boolean, updateFromJanis: func | null}
+ * @returns {object} { hasCheckedUpdate: boolean, shouldUpdateFromJanis: boolean, newVersionNumber: string}
  */
 const appCheckUpdates = async ({buildNumber, isDebug = false, env, app}: IappCheckUpdates) => {
 	const {hasCheckedUpdate, needCheckInJanis} = await updateFromStore({buildNumber, isDebug});

--- a/src/modules/updateFromJanis/index.test.ts
+++ b/src/modules/updateFromJanis/index.test.ts
@@ -35,7 +35,7 @@ describe('App check updates funtion', () => {
 					updateFromJanis({
 						env: invalidValue as any,
 						app: 'wms',
-						newVersion: '1.1.0.2345',
+						newVersionNumber: '1.1.0.2345',
 					})
 				).rejects.toThrow('the parameters are incorrect');
 
@@ -43,7 +43,7 @@ describe('App check updates funtion', () => {
 					updateFromJanis({
 						env: 'janisdev',
 						app: invalidValue as any,
-						newVersion: '1.1.0.2345',
+						newVersionNumber: '1.1.0.2345',
 					})
 				).rejects.toThrow('the parameters are incorrect');
 
@@ -51,7 +51,7 @@ describe('App check updates funtion', () => {
 					updateFromJanis({
 						env: 'janisdev',
 						app: 'wms',
-						newVersion: invalidValue as any,
+						newVersionNumber: invalidValue as any,
 					})
 				).rejects.toThrow('the parameters are incorrect');
 			}
@@ -64,7 +64,7 @@ describe('App check updates funtion', () => {
 				updateFromJanis({
 					env: 'janisdev',
 					app: 'wms',
-					newVersion: '2.0.0.2345',
+					newVersionNumber: '2.0.0.2345',
 				})
 			).rejects.toThrow('You do not have permissions for external storage');
 		});
@@ -77,7 +77,7 @@ describe('App check updates funtion', () => {
 				updateFromJanis({
 					env: 'janisdev',
 					app: 'wms',
-					newVersion: '2.0.0.2345',
+					newVersionNumber: '2.0.0.2345',
 				})
 			).rejects.toThrow('You do not have permissions for external storage');
 		});
@@ -89,7 +89,7 @@ describe('App check updates funtion', () => {
 				updateFromJanis({
 					env: 'janisdev',
 					app: 'wms',
-					newVersion: '2.0.0.2345',
+					newVersionNumber: '2.0.0.2345',
 				})
 			).rejects.toThrow('Error');
 		});
@@ -100,7 +100,7 @@ describe('App check updates funtion', () => {
 				updateFromJanis({
 					env: 'janisdev',
 					app: 'wms',
-					newVersion: '2.0.0.2345',
+					newVersionNumber: '2.0.0.2345',
 				})
 			).rejects.toThrow('Error');
 		});
@@ -113,7 +113,7 @@ describe('App check updates funtion', () => {
 				updateFromJanis({
 					env: 'janisdev',
 					app: 'wms',
-					newVersion: '2.0.0.2345',
+					newVersionNumber: '2.0.0.2345',
 				})
 			).resolves.toEqual(true);
 		});
@@ -123,7 +123,7 @@ describe('App check updates funtion', () => {
 				updateFromJanis({
 					env: 'janisdev',
 					app: 'wms',
-					newVersion: '2.0.0.2345',
+					newVersionNumber: '2.0.0.2345',
 					DownloadProgressCallback: null as any,
 				})
 			).resolves.toEqual(true);
@@ -135,7 +135,7 @@ describe('App check updates funtion', () => {
 				updateFromJanis({
 					env: 'janisdev',
 					app: 'wms',
-					newVersion: '2.0.0.2345',
+					newVersionNumber: '2.0.0.2345',
 					DownloadProgressCallback,
 				})
 			).resolves.toEqual(true);

--- a/src/modules/updateFromJanis/index.test.ts
+++ b/src/modules/updateFromJanis/index.test.ts
@@ -1,3 +1,4 @@
+// import {Platform} from 'react-native';
 import updateFromJanis from './index';
 import * as utils from '../../utils';
 
@@ -16,120 +17,128 @@ jest.mock('react-native//Libraries/PermissionsAndroid/PermissionsAndroid', () =>
 		requestMultiple: mockRequestMultiple,
 	};
 });
+const mockVersion = jest.fn().mockReturnValue(14);
+
+jest.mock('react-native/Libraries/Utilities/Platform', () => {
+	const Platform = jest.requireActual('react-native/Libraries/Utilities/Platform');
+	Object.defineProperty(Platform, 'Version', {
+		get: mockVersion,
+	});
+	return Platform;
+});
 describe('App check updates funtion', () => {
 	describe('Error handling', () => {
 		it.each(['', 5, [], {}, jest.fn(), undefined, null, NaN])(
 			'param is not valid',
 			async (invalidValue) => {
-				const updateTestEnv = updateFromJanis({
-					env: invalidValue as any,
-					app: 'wms',
-					currentVersion: '1.1.0',
-					buildNumber: '10',
-				});
-				expect(await updateTestEnv()).toBeFalsy();
-				const updateTestApp = updateFromJanis({
-					env: 'janis',
-					app: invalidValue as any,
-					currentVersion: '1.1.0',
-					buildNumber: '10',
-				});
-				expect(await updateTestApp()).toBeFalsy();
-				const updateTestCv = updateFromJanis({
-					env: 'janis',
-					app: 'wms',
-					currentVersion: invalidValue as any,
-					buildNumber: '10',
-				});
-				expect(await updateTestCv()).toBeFalsy();
-				const updateTestBn = updateFromJanis({
-					env: 'janis',
-					app: 'wms',
-					currentVersion: '1.1.0',
-					buildNumber: invalidValue as any,
-				});
-				expect(await updateTestBn()).toBeFalsy();
+				await expect(
+					updateFromJanis({
+						env: invalidValue as any,
+						app: 'wms',
+						newVersion: '1.1.0.2345',
+					})
+				).rejects.toThrow('the parameters are incorrect');
+
+				await expect(
+					updateFromJanis({
+						env: 'janisdev',
+						app: invalidValue as any,
+						newVersion: '1.1.0.2345',
+					})
+				).rejects.toThrow('the parameters are incorrect');
+
+				await expect(
+					updateFromJanis({
+						env: 'janisdev',
+						app: 'wms',
+						newVersion: invalidValue as any,
+					})
+				).rejects.toThrow('the parameters are incorrect');
 			}
 		);
 
 		it('does not have to read storage permissions', async () => {
 			mockCheck.mockResolvedValueOnce(false);
-			const updateFn = updateFromJanis({
-				env: 'janisdev',
-				app: 'wms',
-				currentVersion: '1.1.0',
-				buildNumber: '10',
-			});
-			expect(await updateFn()).toEqual(false);
+			mockVersion.mockReturnValueOnce(25);
+			await expect(
+				updateFromJanis({
+					env: 'janisdev',
+					app: 'wms',
+					newVersion: '2.0.0.2345',
+				})
+			).rejects.toThrow('You do not have permissions for external storage');
 		});
 
 		it('does not have to write storage permissions', async () => {
 			mockCheck.mockResolvedValueOnce(true);
 			mockCheck.mockResolvedValueOnce(false);
-			const updateFn = updateFromJanis({
-				env: 'janisdev',
-				app: 'wms',
-				currentVersion: '1.1.0',
-				buildNumber: '10',
-			});
-			expect(await updateFn()).toEqual(false);
+
+			expect(
+				updateFromJanis({
+					env: 'janisdev',
+					app: 'wms',
+					newVersion: '2.0.0.2345',
+				})
+			).rejects.toThrow('You do not have permissions for external storage');
 		});
 
 		it('dont log the error', async () => {
-			mockCheck.mockRejectedValueOnce(new Error());
+			mockCheck.mockRejectedValueOnce(new Error('Error'));
 			mockIsDevEnv.mockReturnValueOnce(false);
-			const updateFn = updateFromJanis({
-				env: 'janisdev',
-				app: 'wms',
-				currentVersion: '1.1.0',
-				buildNumber: '10',
-			});
-			expect(await updateFn()).toEqual(false);
+			await expect(
+				updateFromJanis({
+					env: 'janisdev',
+					app: 'wms',
+					newVersion: '2.0.0.2345',
+				})
+			).rejects.toThrow('Error');
 		});
 		it('log the error in dev env', async () => {
-			mockCheck.mockRejectedValueOnce(new Error());
+			mockCheck.mockRejectedValueOnce(new Error('Error'));
 			mockIsDevEnv.mockReturnValueOnce(true);
-			const updateFn = updateFromJanis({
-				env: 'janisdev',
-				app: 'wms',
-				currentVersion: '1.1.0',
-				buildNumber: '10',
-			});
-			expect(await updateFn()).toEqual(false);
+			await expect(
+				updateFromJanis({
+					env: 'janisdev',
+					app: 'wms',
+					newVersion: '2.0.0.2345',
+				})
+			).rejects.toThrow('Error');
 		});
 	});
 
 	describe('Works correctly', () => {
-		it('works correctly in janisdev environment', async () => {
-			mockCheck.mockResolvedValue(true);
-			const updateFn = updateFromJanis({
-				env: 'janisdev',
-				app: 'wms',
-				currentVersion: '1.1.0',
-				buildNumber: '10',
-			});
-			expect(await updateFn()).toEqual(true);
+		it('works correctly in janisdev environment without asking permissions', async () => {
+			mockVersion.mockReturnValueOnce(33);
+			await expect(
+				updateFromJanis({
+					env: 'janisdev',
+					app: 'wms',
+					newVersion: '2.0.0.2345',
+				})
+			).resolves.toEqual(true);
 		});
 		it('works correctly in janisqa environment with invalid callback', async () => {
 			mockCheck.mockResolvedValue(true);
-			const updateFn = updateFromJanis({
-				env: 'janisqa',
-				app: 'wms',
-				currentVersion: '1.1.0',
-				buildNumber: '10',
-			});
-			expect(await updateFn(null as any)).toEqual(true);
+			await expect(
+				updateFromJanis({
+					env: 'janisdev',
+					app: 'wms',
+					newVersion: '2.0.0.2345',
+					DownloadProgressCallback: null as any,
+				})
+			).resolves.toEqual(true);
 		});
 		it('works correctly in janis environment with valid callback', async () => {
 			mockCheck.mockResolvedValue(true);
-			const callback = () => {};
-			const updateFn = updateFromJanis({
-				env: 'janis',
-				app: 'wms',
-				currentVersion: '1.1.0',
-				buildNumber: '10',
-			});
-			expect(await updateFn(callback)).toEqual(true);
+			const DownloadProgressCallback = () => {};
+			await expect(
+				updateFromJanis({
+					env: 'janisdev',
+					app: 'wms',
+					newVersion: '2.0.0.2345',
+					DownloadProgressCallback,
+				})
+			).resolves.toEqual(true);
 		});
 	});
 });

--- a/src/modules/updateFromJanis/index.ts
+++ b/src/modules/updateFromJanis/index.ts
@@ -5,7 +5,7 @@ import {isDevEnv, isString} from '../../utils';
 interface IappCheckUpdates {
 	env: 'janisdev' | 'janisqa' | 'janis';
 	app: 'picking' | 'delivery' | 'wms';
-	newVersion: string;
+	newVersionNumber: string;
 	DownloadProgressCallback?: () => void;
 }
 
@@ -21,12 +21,19 @@ interface IappCheckUpdates {
 const updateFromJanis = async ({
 	env,
 	app,
-	newVersion,
+	newVersionNumber,
 	DownloadProgressCallback,
 }: IappCheckUpdates) => {
 	const isDevEnvironment = isDevEnv();
 	try {
-		if (!isString(env) || !env || !isString(app) || !app || !isString(newVersion) || !newVersion) {
+		if (
+			!isString(env) ||
+			!env ||
+			!isString(app) ||
+			!app ||
+			!isString(newVersionNumber) ||
+			!newVersionNumber
+		) {
 			throw new Error('the parameters are incorrect');
 		}
 
@@ -64,7 +71,7 @@ const updateFromJanis = async ({
 
 		const response = await RNFS.downloadFile({
 			fromUrl: validUrl,
-			toFile: `${RNFS.DownloadDirectoryPath}/${app}-apk/${app}${envVersion[env]}.${newVersion}.apk`,
+			toFile: `${RNFS.DownloadDirectoryPath}/${app}-apk/${app}${envVersion[env]}.${newVersionNumber}.apk`,
 			progress,
 		}).promise;
 

--- a/src/modules/updateFromJanis/index.ts
+++ b/src/modules/updateFromJanis/index.ts
@@ -1,12 +1,12 @@
-import {PermissionsAndroid} from 'react-native';
+import {PermissionsAndroid, Platform} from 'react-native';
 import RNFS from 'react-native-fs';
 import {isDevEnv, isString} from '../../utils';
 
 interface IappCheckUpdates {
 	env: 'janisdev' | 'janisqa' | 'janis';
 	app: 'picking' | 'delivery' | 'wms';
-	buildNumber: string;
-	currentVersion: string;
+	newVersion: string;
+	DownloadProgressCallback?: () => void;
 }
 
 /**
@@ -14,28 +14,26 @@ interface IappCheckUpdates {
  * @description It is responsible for downloading the apk with the latest version of the app from janis
  * @param {string} env environment of janis
  * @param {string} app App name
- * @param {string} currentVersion new version of the app
- * @param {string} buildNumber new buildNumber of the app
+ * @param {string} newVersion new version of the app
+ * @param {function} DownloadProgressCallback function that monitors the download progress
  * @returns {boolean} if you can download the new apk correctly
  */
-const updateFromJanis = ({env, app, currentVersion, buildNumber}: IappCheckUpdates) => {
-	return async (DownloadProgressCallback?: () => void) => {
-		const isDevEnvironment = isDevEnv();
-		try {
-			if (
-				!isString(env) ||
-				!env ||
-				!isString(app) ||
-				!app ||
-				!isString(buildNumber) ||
-				!buildNumber ||
-				!isString(currentVersion) ||
-				!currentVersion
-			) {
-				return false;
-			}
-			const validUrl = `https://mobile.${env}.in/api/download/${app}/android/latest`;
+const updateFromJanis = async ({
+	env,
+	app,
+	newVersion,
+	DownloadProgressCallback,
+}: IappCheckUpdates) => {
+	const isDevEnvironment = isDevEnv();
+	try {
+		if (!isString(env) || !env || !isString(app) || !app || !isString(newVersion) || !newVersion) {
+			throw new Error('the parameters are incorrect');
+		}
 
+		const validUrl = `https://mobile.${env}.in/api/download/${app}/android/latest`;
+		const apiVersion = Platform.Version;
+
+		if (Number(apiVersion) < 33) {
 			await PermissionsAndroid.requestMultiple([
 				PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
 				PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE,
@@ -48,35 +46,36 @@ const updateFromJanis = ({env, app, currentVersion, buildNumber}: IappCheckUpdat
 				PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
 			);
 			if (!readGranted || !writeGranted) {
-				return false;
+				throw new Error('You do not have permissions for external storage');
 			}
-			const envVersion = {
-				janisdev: '-beta',
-				janisqa: '-qa',
-				janis: '',
-			};
-
-			await RNFS.mkdir(`${RNFS.DownloadDirectoryPath}/${app}-apk`);
-
-			/* istanbul ignore next */
-			const progress =
-				typeof DownloadProgressCallback === 'function' ? DownloadProgressCallback : () => {};
-
-			const response = await RNFS.downloadFile({
-				fromUrl: validUrl,
-				toFile: `${RNFS.DownloadDirectoryPath}/${app}-apk/${app}${envVersion[env]}.${currentVersion}.${buildNumber}.apk`,
-				progress,
-			}).promise;
-
-			return response.statusCode === 200;
-		} catch (error) {
-			if (isDevEnvironment) {
-				// eslint-disable-next-line no-console
-				console.error(error);
-			}
-			return false;
 		}
-	};
+
+		const envVersion = {
+			janisdev: '-beta',
+			janisqa: '-qa',
+			janis: '',
+		};
+
+		await RNFS.mkdir(`${RNFS.DownloadDirectoryPath}/${app}-apk`);
+
+		/* istanbul ignore next */
+		const progress =
+			typeof DownloadProgressCallback === 'function' ? DownloadProgressCallback : () => {};
+
+		const response = await RNFS.downloadFile({
+			fromUrl: validUrl,
+			toFile: `${RNFS.DownloadDirectoryPath}/${app}-apk/${app}${envVersion[env]}.${newVersion}.apk`,
+			progress,
+		}).promise;
+
+		return response.statusCode === 200;
+	} catch (error) {
+		if (isDevEnvironment) {
+			// eslint-disable-next-line no-console
+			console.error(error);
+		}
+		return Promise.reject(error);
+	}
 };
 
 export default updateFromJanis;

--- a/src/modules/updateFromStore/index.ts
+++ b/src/modules/updateFromStore/index.ts
@@ -20,7 +20,7 @@ const updateFromStore = async ({buildNumber, isDebug = false}: IappCheckUpdates)
 	const isDevEnvironment = isDevEnv();
 	try {
 		if (!isString(buildNumber) || !buildNumber) {
-			return defaultResponse;
+			throw new Error('the parameters are incorrect');
 		}
 		const inAppUpdates = await new SpInAppUpdates(isDebug);
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -59,6 +59,7 @@ interface IcheckNeedsUpdateInJanis {
 export const defaultResponse = {
 	hasCheckedUpdate: false,
 	shouldUpdateFromJanis: false,
+	newVersionNumber: '',
 };
 
 /**
@@ -67,7 +68,7 @@ export const defaultResponse = {
  * @param {string} env environment of janis
  * @param {string} app App name
  * @param {string} buildNumber current version of the App
- * @returns {object} { hasCheckedUpdate: boolean, shouldUpdateFromJanis: boolean, updateFromJanis: func | null}
+ * @returns {object} { hasCheckedUpdate: boolean, shouldUpdateFromJanis: boolean, newVersionNumber: string}
  */
 export const checkNeedsUpdateInJanis = async ({
 	env,
@@ -104,6 +105,7 @@ export const checkNeedsUpdateInJanis = async ({
 		return {
 			hasCheckedUpdate: true,
 			shouldUpdateFromJanis: vCompRes > 0,
+			newVersionNumber: `${currentVersion}.${currentBuildNumber}`,
 		};
 	} catch (error) {
 		if (isDevEnv()) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,4 @@
 import SpInAppUpdates, {IAUInstallStatus, StatusUpdateEvent} from 'sp-react-native-in-app-updates';
-import updateFromJanis from '../modules/updateFromJanis';
 /* istanbul ignore next */
 /**
  * @name isDevEnv
@@ -60,7 +59,6 @@ interface IcheckNeedsUpdateInJanis {
 export const defaultResponse = {
 	hasCheckedUpdate: false,
 	shouldUpdateFromJanis: false,
-	updateFromJanis: null,
 };
 
 /**
@@ -85,7 +83,7 @@ export const checkNeedsUpdateInJanis = async ({
 			!isString(app) ||
 			!app
 		) {
-			return defaultResponse;
+			throw new Error('the parameters are incorrect');
 		}
 
 		const validUrl = `https://cdn.mobile.${env}.in/${app}/android/versions.json`;
@@ -98,7 +96,7 @@ export const checkNeedsUpdateInJanis = async ({
 			!currentVersion ||
 			!isString(currentVersion)
 		) {
-			return defaultResponse;
+			throw new Error('API response with incorrect parameters');
 		}
 
 		const vCompRes = customVersionComparator(currentBuildNumber, buildNumber);
@@ -106,12 +104,6 @@ export const checkNeedsUpdateInJanis = async ({
 		return {
 			hasCheckedUpdate: true,
 			shouldUpdateFromJanis: vCompRes > 0,
-			updateFromJanis: updateFromJanis({
-				env,
-				app,
-				currentVersion,
-				buildNumber: currentBuildNumber,
-			}),
 		};
 	} catch (error) {
 		if (isDevEnv()) {


### PR DESCRIPTION
### Link del ticket:
https://janiscommerce.atlassian.net/browse/APPSRN-249

### Contexto:
Para mantener las apps de los usuarios actualizadas creamos el package [npm: @janiscommerce/app-check-updates](https://www.npmjs.com/package/@janiscommerce/app-check-updates) que les notifica cada vez que hay una nueva versión disponible en la play store, lo descarga e instala, agilizando mucho el proceso antiguo.

Sin embargo tenemos ciertos clientes como carrefour o walmart que por motivos de seguridad, tienen bloqueado el acceso a play stores en los dispositivos. Esto trae como consecuencia que no puedan actualizar de una manera eficiente, que el equipo de desarrollo tenga que armar apks de manera manual y enviarle al PO de cada proyecto para que después puedan enviarla al cliente.

En Janis v1 se creo lo que se conoce como [JAM](https://janiscommerce.atlassian.net/wiki/spaces/JAN/pages/424378445/App+de+Picking+con+JAM+Janis+App+Manager) acronimo de Janis app manager. Esto le permite a los clientes mediante esta app podes ver si hay versiones nuevas de las apps de janis v1 y actualizar, todo por fuera del ecosistema de Play store.

### Necesidad:
Implementar una herramienta que facilite la publicación y distribución de las nuevas versiones de las apps sin necesidad de usar play store.

### Analisis funcional:
### Actualización 
Se cambia la exportacion del package, de ser solo 1 funcion por default a exportar modulos. 
La funcion updateFromJanis se exporta directamente del package junto a appCheckUpdates.
La respuesta de appCheckUpdates ahora sera 
const response = {
	hasCheckedUpdate: boolean,
	shouldUpdateFromJanis: boolean,
	newVersionNumber: string,
};
Modificaciones en updateFromJanis

- Ya no se pediran permisos de escritura y lectura del storage para versiones de android superior a 13 ya que no es necesario.
- La funcion ahora retornara el error en caso de haber alguno.
- Ahora recibe el parametro newVersionNumber para nombrar a la apk a descargar.

### Como se puede probar?:
Instalandolo localmente con yalc sigiendo esta guia: [link](https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI)
Sustituyendo el package a linkear por @janiscommerce/app-check-updates

Instalar la peerDependenci en caso de no tenerlas ya

npm install sp-react-native-in-app-updates@1.2.0
npm i react-native-fs

luego en la home se importa la funcion y se ejecuta en algun useefect

import { appCheckUpdates, updateFromJanis } from '@janiscommerce/app-check-updates';

Ejecutar de esta manera

const testFn = async () => {
   try {
	const {hasCheckedUpdate, shouldUpdateFromJanis} = await appCheckUpdates({
		buildNumber: BUILD_NUMBER,
		env: JANIS_ENV,
		app: 'picking',
	});

	if (hasCheckedUpdate) {
		// se chequeo exitosamente, setear timestamp
	}

	if (shouldUpdateFromJanis) {
		// mostrar custom modal consultando si se desea actualizar, 
                // en caso afirmativo ejecutar esta funcion, comenzar la descarga de apk mediante janis
		// setear algun loading antes y despues de ejecutarlo para saber cuando termine
		await updateFromJanis({
					env: 'janisdev',
					app: 'picking',
					newVersion: '1.0.0.2345',
				})
	}
   } catch (error) {
	   console.error(error);
	}

};;
Las actualizaciones de la aplicación están disponibles solo para las cuentas de usuario que poseen la aplicación. Por lo tanto,
si en el emulador alguna vez descargaron la app desde la app store va a chequear siempre con la app store solamente, en cambio si nunca se descargo desde la app store va a verificar por janis, esto seria lo ideal para probar este desarrollo.

Una vez que tengamos una respuesta positiva de updateFromJanis (responde true cuando sale todo ok y false si falla algo), podemos ingresar a la carpeta de descargas del telefono y ver el apk.

![Captura de pantalla de 2023-12-12 10-39-44](https://github.com/janis-commerce/app-check-updates/assets/69169114/5b43c842-c67f-4164-a534-2e7c433a65b0)
