### PR TITLE
added custom download folder generation by app environment

### DIFF
--- a/src/modules/updateFromJanis/index.ts
+++ b/src/modules/updateFromJanis/index.ts
@@ -27,7 +27,7 @@ const updateFromJanis = async ({
 }: IappCheckUpdates) => {
 	const isDevEnvironment = isDevEnv();
 	try {
-		Crashlytics.log('updateFromJanis started', {env, app, newVersionNumber});
+		Crashlytics.log('updateFromJanis:', {env, app, newVersionNumber});
 		if (
 			!isString(env) ||
 			!env ||

--- a/src/modules/updateFromJanis/index.ts
+++ b/src/modules/updateFromJanis/index.ts
@@ -14,7 +14,7 @@ const envMapper = {
 	janisdev: '-beta',
 	janisqa: '-qa',
 	janis: '',
-};
+} as const;
 
 /**
  * @name updateFromJanis

--- a/src/modules/updateFromStore/index.ts
+++ b/src/modules/updateFromStore/index.ts
@@ -20,7 +20,7 @@ const defaultResponse = {hasCheckedUpdate: false, needCheckInJanis: false};
 const updateFromStore = async ({buildNumber, isDebug = false}: IappCheckUpdates) => {
 	const isDevEnvironment = isDevEnv();
 	try {
-		Crashlytics.log('updateFromStore started', {buildNumber});
+		Crashlytics.log('updateFromStore:', {buildNumber});
 		if (!isString(buildNumber) || !buildNumber) {
 			throw new Error('the parameters are incorrect');
 		}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -87,7 +87,7 @@ export const checkNeedsUpdateInJanis = async ({
 		) {
 			throw new Error('the parameters are incorrect');
 		}
-
+		Crashlytics.log('checkNeedsUpdateInJanis:', {env, app, buildNumber});
 		const validUrl = `https://cdn.mobile.${env}.in/${app}/android/versions.json`;
 		const response = await fetch(validUrl);
 		const {currentBuildNumber, currentVersion} = await response.json();


### PR DESCRIPTION
## DESCRIPCIÓN DE LA SOLUCIÓN:
Se ajustó el comportamiento de descarga; ahora, dependiendo el ambiente, se genera una carpeta de descarga particular que está asociada al mismo, siendo:
- beta => picking-beta-apk / delivery-beta-apk
- QA => picking-qa-apk / delivery-qa-apk
- prod => picking-apk / delivery-apk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Ensures APK downloads use consistent environment-specific suffixes (-beta, -qa, or none) for clearer identification.
  - Automatically clears any existing download folder before starting a new download to prevent conflicts and failed installs.

- Refactor
  - Centralized environment-to-suffix mapping for more reliable path resolution.

- Tests
  - Updated test cases to reflect new environment mappings and adjusted download progress handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->