### PR TITLE
Appsrn 445 soporte para actualización de apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,10 @@
 			},
 			"peerDependencies": {
 				"@janiscommerce/app-crashlytics": ">=2.1.0",
-				"react": ">=17.0.2",
-				"react-native": ">=0.67.5",
+				"react": ">=17.0.2 <19.0.0",
+				"react-native": ">=0.67.5 <0.75.0",
 				"react-native-fs": ">=2.20.0",
-				"sp-react-native-in-app-updates": "1.2.0"
+				"sp-react-native-in-app-updates": ">=1.2.0"
 			}
 		},
 		".yalc/@janiscommerce/app-check-updates": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
 	},
 	"peerDependencies": {
 		"@janiscommerce/app-crashlytics": ">=2.1.0",
-		"react": ">=17.0.2",
-		"react-native": ">=0.67.5",
+		"react": ">=17.0.2 <19.0.0",
+		"react-native": ">=0.67.5 <0.75.0",
 		"react-native-fs": ">=2.20.0",
-		"sp-react-native-in-app-updates": "1.2.0"
+		"sp-react-native-in-app-updates": ">=1.2.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.12.9",


### PR DESCRIPTION
## LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/APPSRN-445

## DESCRIPCIÓN DEL REQUERIMIENTO:
Se requieren realizar ciertos ajustes a la librería para que la misma soporte la actualización de versión de React y React Native de las APPs y, a la vez, nos permita eliminar las flags de --legacy-peer-deps / --force a la hora de tirar un npm i dentro del repo de las APPs.

## DESCRIPCIÓN DE LA SOLUCIÓN:
Los ajustes que se hicieron fueron:

Ajustar las peerDependencies

react: 18.2.0 → >=17.0.2 <19.0.0

react-native: 0.71.5 → >=0.67.5 <0.75.0

sp-react-native-in-app-updates: 1.2.0 → >=1.2.0

## CÓMO PROBAR?

Vincular el pkg a la app y verificar que funcione correctamente

## DATOS EXTRA A TENER EN CUENTA:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated peer dependencies to support a wider range of React and React Native versions.
  * Updated in-app updates library dependency to allow newer minor and patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->